### PR TITLE
Implement Shopping Basket System with Offers and Delivery Rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,81 @@
+# Acme Widget Co – Basket
+
+Acme Widget Basket is a proof-of-concept shopping basket system for Acme Widget Co.
+It supports product pricing, delivery rules, and special offers like “buy one red widget, get the second half price.
+
+## Features
+- Small, focused classes with clear interfaces
+- Strategy pattern for delivery and offers
+- Dependency injection for rules and product catalogue
+- Money operations via `BigDecimal` to avoid float errors
+- Minitest unit tests
+
+
+## Assumptions
+- Delivery charges apply **after** offers are applied.
+- Multiple offers can be injected.
+- Unknown product codes raise an error.
+
+## Repository Structure
+
+```
+acme-widget-basket/
+├─ README.md
+├─ Rakefile
+├─ main.rb
+├─ lib/
+│  ├─ acme_basket.rb
+│  ├─ catalogue.rb
+│  ├─ product.rb
+│  ├─ basket.rb
+│  ├─ money.rb
+│  ├─ delivery_rule.rb/
+│  └─ offers/
+│     ├─ offer.rb
+│     └─ red_widget_offer.rb
+└─ test/
+   ├─ test_helper.rb
+   ├─ basket_test.rb
+   ├─ delivery_test.rb
+   └─ offers_test.rb
+```
+
+## How It Works
+
+### Catalogue & Products
+The basket is initialized with a catalogue of products (`R01`, `G01`, `B01`) including their names and prices.
+
+### Adding Items
+Use the `Basket#add` method (or pass product codes via `main.rb`) to add items. Invalid codes are detected and reported.
+
+### Offers & Discounts
+Special offers (like “buy one red widget, get the second half price”) are implemented as separate classes extending a base `Offer` class. The basket applies all offers automatically when calculating the total.
+
+### Delivery Rules
+Delivery cost is calculated based on the subtotal using a `DeliveryRule`. Orders over $90 are free, orders $50–$89.99 cost $2.95, and orders under $50 cost $4.95.
+
+### Calculating Total
+The basket computes the subtotal, subtracts any discounts from offers, adds delivery charges, and rounds to two decimal places for the final total.
+
+### Extensibility
+New products, offers, or delivery rules can be added easily without changing the core basket logic each rule lives in its own class, keeping the system modular and maintainable.
+
+## Examples To Run
+
+```
+ruby main.rb R01 G01
+
+ruby main.rb R01 R01
+
+ruby main.rb  B01 B01 R01 R01 R01
+```
+
+## Run Test cases
+
+```
+rake 
+
+or 
+
+rake test
+```

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'rake/testtask'
+
+Rake::TestTask.new do |t|
+  t.libs << 'test'
+  t.libs << 'lib'
+  t.pattern = 'test/**/*_test.rb'
+  t.verbose = true
+end
+
+task default: :test

--- a/lib/acme_basket.rb
+++ b/lib/acme_basket.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# Central require to load the library in one go
+
+require_relative 'money'
+require_relative 'product'
+require_relative 'catalogue'
+require_relative 'basket'
+require_relative 'delivery_rule'
+require_relative 'offers/offer'
+require_relative 'offers/red_widget_offer'

--- a/lib/basket.rb
+++ b/lib/basket.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require_relative 'money'
+
+class Basket
+  include Money
+
+  def initialize(catalogue:, delivery_rule:, offers: [])
+    @catalogue = catalogue
+    @delivery_rule = delivery_rule
+    @offers = offers
+    @items = []
+  end
+
+  def add(code)
+    product = @catalogue.fetch(code)
+    @items << product
+  end
+
+  def total
+    subtotal = @items.sum { |p| Money.dec(p.price) }
+    discount = @offers.sum { |offer| offer.discount(@items) }
+    adjusted_total = subtotal - discount
+    delivery = @delivery_rule.calculate(adjusted_total)
+    Money.round2(adjusted_total + delivery)
+  end
+
+  def total_formatted
+    Money.format(total)
+  end
+
+  # Returns a copy of the basket items.
+  # This way, outside code can look at the contents without accidentally changing the basket itself.
+  def items
+    @items.dup
+  end
+end

--- a/lib/catalogue.rb
+++ b/lib/catalogue.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require_relative 'money'
+
+class Catalogue
+  include Money
+
+  def initialize(products = [])
+    @by_code = {}
+    products.each { |p| add(p) }
+  end
+
+  def add(product)
+    @by_code[product.code] = product
+  end
+
+  def fetch(code)
+    @by_code.fetch(code) { raise ArgumentError, "Unknown product code: #{code}" }
+  end
+
+  def include?(code)
+    @by_code.key?(code)
+  end
+end

--- a/lib/delivery_rule.rb
+++ b/lib/delivery_rule.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require_relative 'money'
+
+class DeliveryRule
+  include Money
+
+  def calculate(subtotal)
+    s = Money.dec(subtotal)
+
+    return Money.dec(0) if s >= 90
+    return Money.dec(2.95) if s >= 50
+
+    Money.dec(4.95)
+  end
+end

--- a/lib/money.rb
+++ b/lib/money.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'bigdecimal'
+require 'bigdecimal/util'
+
+module Money
+  module_function
+
+  def dec(n)
+    case n
+    when BigDecimal then n
+    when String then n.to_d
+    else n.to_d
+    end
+  end
+
+  def round2(n)
+    dec(n).round(2, BigDecimal::ROUND_HALF_DOWN)
+  end
+
+  # Use Kernel.format explicitly to avoid calling Money.format recursively.
+  # This ensures we’re using Ruby’s built-in string formatter, not our own method.
+  def format(n)
+    Kernel.format('$%.2f', round2(n).to_f)
+  end
+end

--- a/lib/offers/offer.rb
+++ b/lib/offers/offer.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Offer
+  def discount(items)
+    raise NotImplementedError, 'implement in subclass'
+  end
+end

--- a/lib/offers/red_widget_offer.rb
+++ b/lib/offers/red_widget_offer.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require_relative '../money'
+require_relative 'offer'
+
+# This class is designed with extensibility in mind.
+# If future offers are introduced (e.g., for Green or Blue Widgets),
+# they can be implemented as separate classes in the same way.
+
+class RedWidgetOffer < Offer
+  include Money
+
+  RED_CODE = 'R01'
+
+  def discount(items)
+    red_items = items.select { |p| p.code == RED_CODE }
+    return Money.dec(0) if red_items.empty?
+
+    price = Money.dec(red_items.first.price)
+    pairs = red_items.count / 2
+    # do not round here, let Basket handle final rounding
+    pairs * (price / 2)
+  end
+end

--- a/lib/product.rb
+++ b/lib/product.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class Product
+  attr_reader :code, :name, :price
+
+  def initialize(code:, name:, price:)
+    @code = code
+    @name = name
+    @price = price
+  end
+end

--- a/main.rb
+++ b/main.rb
@@ -1,0 +1,20 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift(File.expand_path('lib', __dir__))
+require 'acme_basket'
+
+catalogue = Catalogue.new([
+                            Product.new(code: 'R01', name: 'Red Widget', price: 32.95),
+                            Product.new(code: 'G01', name: 'Green Widget', price: 24.95),
+                            Product.new(code: 'B01', name: 'Blue Widget', price: 7.95)
+                          ])
+
+delivery_rule = DeliveryRule.new
+offers = [RedWidgetOffer.new]
+
+basket = Basket.new(catalogue: catalogue, delivery_rule: delivery_rule, offers: offers)
+
+ARGV.each { |code| basket.add(code) }
+
+puts basket.total_formatted

--- a/test/basket_test.rb
+++ b/test/basket_test.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require_relative 'test_helper'
+
+class BasketTest < Minitest::Test
+  def setup
+    @basket = Basket.new(catalogue: default_catalogue, delivery_rule: default_delivery, offers: default_offers)
+  end
+
+  def test_b01_g01
+    @basket.add('B01')
+    @basket.add('G01')
+    assert_in_delta 37.85, @basket.total.to_f, 0.001
+  end
+
+  def test_r01_r01
+    @basket.add('R01')
+    @basket.add('R01')
+    assert_in_delta 54.37, @basket.total.to_f, 0.001
+  end
+
+  def test_r01_g01
+    @basket.add('R01')
+    @basket.add('G01')
+    assert_in_delta 60.85, @basket.total.to_f, 0.001
+  end
+
+  def test_mixed
+    %w[B01 B01 R01 R01 R01].each { |c| @basket.add(c) }
+    assert_in_delta 98.27, @basket.total.to_f, 0.001
+  end
+
+  def test_unknown_product
+    assert_raises(ArgumentError) { @basket.add('ZZZ') }
+  end
+end

--- a/test/delivery_test.rb
+++ b/test/delivery_test.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative 'test_helper'
+
+class DeliveryTest < Minitest::Test
+  def setup
+    @rule = DeliveryRule.new
+  end
+
+  def test_under_50
+    assert_in_delta 4.95, @rule.calculate(49.99).to_f, 0.001
+  end
+
+  def test_between_50_and_90
+    assert_in_delta 2.95, @rule.calculate(50).to_f, 0.001
+    assert_in_delta 2.95, @rule.calculate(89.99).to_f, 0.001
+  end
+
+  def test_free_over_90
+    assert_in_delta 0.0, @rule.calculate(90).to_f, 0.001
+  end
+end

--- a/test/offers_test.rb
+++ b/test/offers_test.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require_relative 'test_helper'
+
+class OffersTest < Minitest::Test
+  def setup
+    @offer = RedWidgetOffer.new
+    @red = Product.new(code: 'R01', name: 'Red', price: 32.95)
+    @blue = Product.new(code: 'B01', name: 'Blue', price: 7.95)
+  end
+
+  def test_no_discount_under_two
+    assert_in_delta 0.0, @offer.discount([@red]).to_f, 0.001
+  end
+
+  def test_half_off_second
+    two_reds = [@red, @red]
+    assert_in_delta 16.48, @offer.discount(two_reds).to_f, 0.01
+  end
+
+  def test_ignores_others
+    assert_in_delta 0.0, @offer.discount([@blue, @blue]).to_f, 0.001
+  end
+
+  def test_three_reds
+    three_reds = [@red, @red, @red]
+    assert_in_delta 16.48, @offer.discount(three_reds).to_f, 0.01
+  end
+
+  def test_four_reds
+    four_reds = [@red, @red, @red, @red]
+    assert_in_delta 32.95, @offer.discount(four_reds).to_f, 0.01
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+$LOAD_PATH.unshift(File.expand_path('../lib', __dir__))
+require 'acme_basket'
+
+def default_catalogue
+  Catalogue.new([
+                  Product.new(code: 'R01', name: 'Red Widget', price: 32.95),
+                  Product.new(code: 'G01', name: 'Green Widget', price: 24.95),
+                  Product.new(code: 'B01', name: 'Blue Widget', price: 7.95)
+                ])
+end
+
+def default_delivery
+  DeliveryRule.new
+end
+
+def default_offers
+  [RedWidgetOffer.new]
+end


### PR DESCRIPTION
## Overview

- Added a shopping basket system for Acme Widget Co.
- Supports adding products, applying offers, and calculating delivery charges.

## How It Works

- Catalogue initialized with products (R01, G01, B01).
- `Basket#add` adds items (raises error if invalid code).
- Offer applied: Buy one red widget, get the second half price.
- Delivery rules based on subtotal: under $50 → $4.95, under $90 → $2.95, $90+ → free.
- Final total = subtotal − discounts + delivery.

## Assumptions

- Delivery charges apply **after** offers are applied.
- Multiple offers can be injected.
- Unknown product codes raise an error.

## Testing

- Unit tests with Minitest.
- Run all tests: `rake test`

## Screenshot

<img width="1040" height="342" alt="image" src="https://github.com/user-attachments/assets/8665f610-f78a-4820-a57d-04c6432ab350" />
